### PR TITLE
Update Peugeot 3008 generations: correct production dates and extend second generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# Model make
+# Peugeot 3008
 
+This repository contains signal set configurations for the Peugeot 3008, organized by model year and version. The files are structured to allow for easy differentiation between model generations and other vehicle parameters, ensuring accurate signal mapping for each version of the Peugeot 3008.
+
+## Contributing
+
+Contributions are welcome! If you would like to add support for additional model years or other configurations, please open an issue or submit a pull request.
+
+1. Fork the repository
+2. Create a new branch for your changes
+3. Commit your changes and open a pull request with a detailed description
+
+## Issues
+
+If you encounter any issues or would like to discuss improvements, please feel free to open an issue. We encourage collaboration and appreciate feedback to make the repository as accurate and useful as possible.

--- a/generations.yaml
+++ b/generations.yaml
@@ -1,12 +1,15 @@
+references:
+  - "https://en.wikipedia.org/wiki/Peugeot_3008"
+
 generations:
   - name: "First Generation (T84)"
-    start_year: 2009
+    start_year: 2008
     end_year: 2016
     description: "The original Peugeot 3008 was introduced as a compact crossover with distinctive MPV influences, featuring a relatively tall body, practical interior, and innovative features. The exterior design blended elements of both SUVs and minivans with a rounded profile, distinctive Peugeot family face, and a unique split tailgate that could function as both a conventional hatch and a small pickup-style dropgate. Powertrain options varied by market but typically included gasoline engines from 1.2L to 1.6L and diesel options from 1.6L to 2.0L, with manual and automatic transmission options. A innovative diesel-electric Hybrid4 variant was introduced in 2011, featuring a 2.0L diesel engine powering the front wheels and an electric motor for the rear wheels, creating a through-the-road all-wheel drive system. The interior showcased a cockpit-like design with a high center console, aircraft-style handbrake, and a driver-oriented layout. Notable features included the Grip Control enhanced traction system offering various terrain modes without the complexity and weight of a traditional AWD system, a Head-Up Display, and an available panoramic glass roof. A significant refresh in 2013 brought updated styling with LED signature lighting, improved interior materials, and enhanced technology features. The first-generation 3008 established the model as a practical, innovative option in the growing crossover segment, with strong sales particularly in European markets where its combination of MPV practicality with crossover styling and features appealed to family buyers."
 
   - name: "Second Generation (P84)"
-    start_year: 2017
-    end_year: 2023
+    start_year: 2016
+    end_year: 2024
     description: "The second-generation Peugeot 3008 represented a dramatic reinvention, transforming from a MPV-crossover hybrid into a fully-fledged SUV with bold, contemporary styling. Built on PSA's new EMP2 platform, it features a more muscular stance, distinctive front end with an aggressive grille design, and numerous SUV styling cues including pronounced wheel arches and protective body cladding. Powertrain options expanded to include various PureTech gasoline engines (1.2L to 1.6L), BlueHDi diesel options (1.5L to 2.0L), and plug-in hybrid variants introduced in 2019 offering either front-wheel drive (225 hp combined) or all-wheel drive (300 hp combined) with up to 36 miles of electric-only range. The interior showcases an evolved version of Peugeot's i-Cockpit with a compact steering wheel, 12.3-inch digital instrument display, and 8-inch (later 10-inch) touchscreen, complemented by distinctive toggle switches and high-quality materials. Advanced technology includes semi-autonomous driving features, automated parking, and a comprehensive suite of driver assistance systems. A significant refresh in 2020 brought updated exterior styling with a frameless grille, redesigned lighting elements, and enhanced technology including night vision capabilities on higher trims. The second-generation 3008 achieved critical acclaim, winning European Car of the Year 2017 and numerous other awards, successfully repositioning the model as a premium-feeling offering in the highly competitive compact SUV segment and becoming one of Peugeot's global bestsellers."
 
   - name: "Third Generation (P64)"


### PR DESCRIPTION
- First generation start year corrected from 2009 to 2008 (production began in 2008)
- Second generation end year extended from 2023 to 2024 (production continued until 2024)
- Added Wikipedia reference to generations.yaml
- Updated README.md with proper Peugeot 3008 title and standard template

Evidence: Wikipedia article shows first generation production as 2008-2016 and second generation as October 2016-2024

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
